### PR TITLE
Establish a naming prefix variable.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -45,6 +45,7 @@ jobs:
       TF_BACKEND_CONFIG_region: ((tf-region))
       TF_BACKEND_CONFIG_access_key: ((aws-access-key-id))
       TF_BACKEND_CONFIG_secret_key: ((aws-secret-access-key))
+      TF_VAR_name_prefix: s3pypi
       TF_VAR_aws_access_key: ((aws-access-key-id))
       TF_VAR_aws_secret_key: ((aws-secret-access-key))
     on_failure:
@@ -74,5 +75,6 @@ jobs:
       TF_BACKEND_CONFIG_region: ((tf-region))
       TF_BACKEND_CONFIG_access_key: ((aws-access-key-id))
       TF_BACKEND_CONFIG_secret_key: ((aws-secret-access-key))
+      TF_VAR_name_prefix: s3pypi
       TF_VAR_aws_access_key: ((aws-access-key-id))
       TF_VAR_aws_secret_key: ((aws-secret-access-key))

--- a/s3pypi.tf
+++ b/s3pypi.tf
@@ -1,6 +1,7 @@
 variable "region" {
   default = "us-east-1"
 }
+variable "name_prefix" {}
 variable "aws_access_key" {}
 variable "aws_secret_key" {}
 
@@ -12,9 +13,9 @@ provider "aws" {
 }
 
 resource "aws_s3_bucket" "artifact_bucket" {
-  bucket = "s3pypi-artifacts"
+  bucket = "${var.name_prefix}-artifacts"
 }
 
 resource "aws_s3_bucket" "index_bucket" {
-  bucket = "s3pypi-index"
+  bucket = "${var.name_prefix}-index"
 }


### PR DESCRIPTION
This will let the Terraform template get reused for different
projects (and instantiated by different folks).