### PR TITLE
Mark both S3 buckets as `public-read`

### DIFF
--- a/s3pypi.tf
+++ b/s3pypi.tf
@@ -20,10 +20,15 @@ provider "aws" {
 
 resource "aws_s3_bucket" "artifact_bucket" {
   bucket = "${var.name_prefix}-artifacts"
+  acl = "public-read"
 }
 
 resource "aws_s3_bucket" "index_bucket" {
   bucket = "${var.name_prefix}-index"
+  acl = "public-read"
+  website {
+    index_document = "index.html"
+  }
 }
 
 resource "aws_sns_topic" "update_topic" {


### PR DESCRIPTION
This also designates `index.html` as the page to serve if a
request is made to the root folder or a subfolder of the
index bucket. This is necessary to work properly in accordance
with PEP 503.