### PR TITLE
Upgrade gen-proj-index to 0.1.6.

### DIFF
--- a/s3pypi.tf
+++ b/s3pypi.tf
@@ -8,7 +8,7 @@ variable "gen_index_version" {
   default = "0.1.6"
 }
 variable "gen_proj_index_version" {
-  default = "0.1.5"
+  default = "0.1.6"
 }
 
 provider "aws" {


### PR DESCRIPTION
This builds redirect objects for project indices so they can
be requested with a trailing slash.