### PR TITLE
Give project index lambda proper permissions.

### DIFF
--- a/s3pypi.tf
+++ b/s3pypi.tf
@@ -187,7 +187,8 @@ resource "aws_iam_policy" "generate_proj_index" {
       "Effect" : "Allow",
       "Action" : "s3:*",
       "Resource" : [
-        "arn:aws:s3:::${aws_s3_bucket.index_bucket.bucket}/*/index.html"
+        "arn:aws:s3:::${aws_s3_bucket.index_bucket.bucket}/*/index.html",
+        "arn:aws:s3:::${aws_s3_bucket.index_bucket.bucket}/*/"
       ]
     },
     {


### PR DESCRIPTION
In order to create a trailing-slash redirect, need to actually
let the lambda create that object!