### PR TITLE
Upgrade gen-proj-index lambda to 0.2.1.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *~
 backend.hcl
 *.tfstate
+backend.tf

--- a/s3pypi.tf
+++ b/s3pypi.tf
@@ -8,7 +8,7 @@ variable "gen_index_version" {
   default = "0.1.6"
 }
 variable "gen_proj_index_version" {
-  default = "0.2.0"
+  default = "0.2.1"
 }
 
 provider "aws" {


### PR DESCRIPTION
Should fix content type for trailing slash project indices.